### PR TITLE
Flyttet init av formelkode til konstruktør istedenfor init funksjon. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>no.nav.pensjon.regler</groupId>
 	<artifactId>preg-api</artifactId>
-	<version>10.28.0-SNAPSHOT</version>
+	<version>10.29.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>pensjon-service :: Rule services API</name>
 	<dependencies>
@@ -41,6 +41,7 @@
 	</properties>
 	<build>
 		<sourceDirectory>src/main/kotlin</sourceDirectory>
+		<testSourceDirectory>src/test/kotlin</testSourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/BarnetilleggFellesbarn.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/BarnetilleggFellesbarn.kt
@@ -5,9 +5,15 @@ import no.nav.pensjon.regler.domain.kode.FormelKodeCti
 import no.nav.pensjon.regler.domain.kode.YtelsekomponentTypeCti
 import java.io.Serializable
 
-class BarnetilleggFellesbarn : AbstraktBarnetillegg(), Serializable {
+class BarnetilleggFellesbarn : AbstraktBarnetillegg, Serializable {
+
     init {
-        formelKode = FormelKodeCti("BTx")
         ytelsekomponentType = YtelsekomponentTypeCti("TFB")
     }
+
+    constructor() {
+        formelKode = FormelKodeCti("BTx")
+    }
+
+    constructor (barnetilleggFellesbarn: BarnetilleggFellesbarn) : super(barnetilleggFellesbarn)
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/BarnetilleggSerkullsbarn.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/BarnetilleggSerkullsbarn.kt
@@ -5,9 +5,14 @@ import no.nav.pensjon.regler.domain.kode.FormelKodeCti
 import no.nav.pensjon.regler.domain.kode.YtelsekomponentTypeCti
 import java.io.Serializable
 
-class BarnetilleggSerkullsbarn : AbstraktBarnetillegg(), Serializable {
+class BarnetilleggSerkullsbarn : AbstraktBarnetillegg, Serializable {
     init {
         ytelsekomponentType = YtelsekomponentTypeCti("TSB")
+    }
+
+    constructor() {
         formelKode = FormelKodeCti("BTx")
     }
+
+    constructor(barnetilleggSerkullsbarn: BarnetilleggSerkullsbarn) : super(barnetilleggSerkullsbarn)
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/Ektefelletillegg.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/Ektefelletillegg.kt
@@ -4,7 +4,7 @@ import no.nav.pensjon.regler.domain.kode.AvkortingsArsakCti
 import no.nav.pensjon.regler.domain.kode.FormelKodeCti
 import no.nav.pensjon.regler.domain.kode.YtelsekomponentTypeCti
 
-class Ektefelletillegg : Ytelseskomponent() {
+class Ektefelletillegg : Ytelseskomponent {
     /**
      * Fribeløpet
      */
@@ -23,7 +23,7 @@ class Ektefelletillegg : Ytelseskomponent() {
     /**
      * årsaken(e) til avkorting. Satt dersom avkortet er true.
      */
-     var arsaksList: MutableList<AvkortingsArsakCti> = mutableListOf()
+    var arsaksList: MutableList<AvkortingsArsakCti> = mutableListOf()
 
     /**
      * Angir minste pensjonsnivåsats for ektefelletillegget
@@ -62,6 +62,25 @@ class Ektefelletillegg : Ytelseskomponent() {
 
     init {
         ytelsekomponentType = YtelsekomponentTypeCti("ET")
+    }
+
+    constructor() {
         formelKode = FormelKodeCti("ETx")
+    }
+
+    constructor(ektefelletillegg: Ektefelletillegg) : super(ektefelletillegg) {
+        fribelop = ektefelletillegg.fribelop
+        samletInntektAvkort = ektefelletillegg.samletInntektAvkort
+        avkortet = ektefelletillegg.avkortet
+        mpnSatsFT = ektefelletillegg.mpnSatsFT
+        tt_anv = ektefelletillegg.tt_anv
+        forsorgingstilleggNiva = ektefelletillegg.forsorgingstilleggNiva
+        proratanevner = ektefelletillegg.proratanevner
+        proratateller = ektefelletillegg.proratateller
+        skattefritak = ektefelletillegg.skattefritak
+        arsaksList = ArrayList()
+        for (arsak in ektefelletillegg.arsaksList) {
+            arsaksList.add(AvkortingsArsakCti(arsak.kode))
+        }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/Grunnpensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/Grunnpensjon.kt
@@ -27,14 +27,16 @@ open class Grunnpensjon : Ytelseskomponent {
 
     init {
         ytelsekomponentType = YtelsekomponentTypeCti("GP")
+    }
+
+    constructor() {
         formelKode = FormelKodeCti("GPx")
     }
 
-    constructor()
     /**
      * Copy Constructor
      */
-    constructor(gp: Grunnpensjon) : super(gp){
+    constructor(gp: Grunnpensjon) : super(gp) {
         pSats_gp = gp.pSats_gp
         if (gp.satsType != null) {
             satsType = GPSatsTypeCti(gp.satsType!!)

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/Tilleggspensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/Tilleggspensjon.kt
@@ -44,10 +44,11 @@ open class Tilleggspensjon : Ytelseskomponent, IFormelProvider {
 
     init {
         ytelsekomponentType = YtelsekomponentTypeCti("TP")
-        formelKode = FormelKodeCti("TPx")
     }
 
-    constructor()
+    constructor() {
+        formelKode = FormelKodeCti("TPx")
+    }
     constructor(tilleggspensjon: Tilleggspensjon) : super(tilleggspensjon) {
         if (tilleggspensjon.spt != null) {
             spt = Sluttpoengtall(tilleggspensjon.spt!!)

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AbstraktBarnetillegg.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AbstraktBarnetillegg.kt
@@ -4,7 +4,7 @@ import no.nav.pensjon.regler.domain.beregning.Ytelseskomponent
 import no.nav.pensjon.regler.domain.kode.AvkortingsArsakCti
 import java.io.Serializable
 
-abstract class AbstraktBarnetillegg protected constructor() : Ytelseskomponent(), Serializable {
+abstract class AbstraktBarnetillegg : Ytelseskomponent, Serializable {
     /**
      * Antall barn i kullet.
      */
@@ -58,6 +58,24 @@ abstract class AbstraktBarnetillegg protected constructor() : Ytelseskomponent()
     /**
      * årsaken(e) til avkorting. Satt dersom avkortet er true.
      */
-    var avkortingsArsakList: List<AvkortingsArsakCti> = mutableListOf()
+    var avkortingsArsakList: MutableList<AvkortingsArsakCti> = mutableListOf()
+
+    constructor()
+
+    constructor(ab: AbstraktBarnetillegg) : super(ab) {
+        antallBarn = ab.antallBarn
+        avkortet = ab.avkortet
+        btDiff_eos = ab.btDiff_eos
+        fribelop = ab.fribelop
+        mpnSatsFT = ab.mpnSatsFT
+        proratanevner = ab.proratanevner
+        proratateller = ab.proratateller
+        samletInntektAvkort = ab.samletInntektAvkort
+        tt_anv = ab.tt_anv
+        forsorgingstilleggNiva = ab.forsorgingstilleggNiva
+        for (arsak in ab.avkortingsArsakList) {
+            avkortingsArsakList.add(AvkortingsArsakCti(arsak.kode))
+        }
+    }
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AbstraktBarnetilleggUT.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AbstraktBarnetilleggUT.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.regler.domain.beregning2011
 
 import java.io.Serializable
 
-abstract class AbstraktBarnetilleggUT : AbstraktBarnetillegg(), Serializable, UforetrygdYtelseskomponent {
+abstract class AbstraktBarnetilleggUT : AbstraktBarnetillegg, Serializable, UforetrygdYtelseskomponent {
     /**
      * Detaljer rundt avkortning av netto barnetillegg.
      */
@@ -47,5 +47,18 @@ abstract class AbstraktBarnetilleggUT : AbstraktBarnetillegg(), Serializable, Uf
      * Brukers uføretrygd før justering
      */
     var brukersUforetrygdForJustering = 0
+
+    constructor()
+
+    constructor(ab: AbstraktBarnetilleggUT) : super(ab) {
+        inntektstak = ab.inntektstak
+        nettoAkk = ab.nettoAkk
+        nettoRestAr = ab.nettoRestAr
+        reduksjonsinformasjon = ab.reduksjonsinformasjon
+        avkortingsinformasjon = ab.avkortingsinformasjon
+        periodisertAvvikEtteroppgjor = ab.periodisertAvvikEtteroppgjor
+        tidligereBelopAr = ab.tidligereBelopAr
+        brukersUforetrygdForJustering = ab.brukersUforetrygdForJustering
+    }
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AfpLivsvarig.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AfpLivsvarig.kt
@@ -4,14 +4,22 @@ import no.nav.pensjon.regler.domain.beregning.Ytelseskomponent
 import no.nav.pensjon.regler.domain.kode.FormelKodeCti
 import no.nav.pensjon.regler.domain.kode.YtelsekomponentTypeCti
 
-open class AfpLivsvarig : Ytelseskomponent() {
+open class AfpLivsvarig : Ytelseskomponent {
     var justeringsbelop = 0
     var afpProsentgrad = 0.0
     var afpForholdstall = 0.0
 
     init {
-        formelKode = FormelKodeCti("AFPx")
         ytelsekomponentType = YtelsekomponentTypeCti("AFP_LIVSVARIG")
     }
 
+    constructor() {
+        formelKode = FormelKodeCti("AFPx")
+    }
+
+    constructor(o: AfpLivsvarig) : super(o) {
+        afpForholdstall = o.afpForholdstall
+        afpProsentgrad = o.afpProsentgrad
+        justeringsbelop = o.justeringsbelop
+    }
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BarnetilleggFellesbarnUT.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BarnetilleggFellesbarnUT.kt
@@ -4,7 +4,7 @@ import no.nav.pensjon.regler.domain.kode.FormelKodeCti
 import no.nav.pensjon.regler.domain.kode.YtelsekomponentTypeCti
 import java.io.Serializable
 
-class BarnetilleggFellesbarnUT : AbstraktBarnetilleggUT(), Serializable {
+class BarnetilleggFellesbarnUT : AbstraktBarnetilleggUT, Serializable {
     /**
      * beløp som er fratrukket annen forelders inntekt (inntil 1G)
      */
@@ -26,7 +26,17 @@ class BarnetilleggFellesbarnUT : AbstraktBarnetilleggUT(), Serializable {
     var annenForelderUforetrygdForJustering = 0
 
     init {
-        formelKode = FormelKodeCti("BTx")
         ytelsekomponentType = YtelsekomponentTypeCti("UT_TFB")
+    }
+
+    constructor() {
+        formelKode = FormelKodeCti("BTx")
+    }
+
+    constructor(barnetilleggFellesbarnUT: BarnetilleggFellesbarnUT) : super(barnetilleggFellesbarnUT) {
+        belopFratrukketAnnenForeldersInntekt = barnetilleggFellesbarnUT.belopFratrukketAnnenForeldersInntekt
+        brukersInntektTilAvkortning = barnetilleggFellesbarnUT.brukersInntektTilAvkortning
+        inntektAnnenForelder = barnetilleggFellesbarnUT.inntektAnnenForelder
+        annenForelderUforetrygdForJustering = barnetilleggFellesbarnUT.annenForelderUforetrygdForJustering
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BarnetilleggSerkullsbarnUT.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BarnetilleggSerkullsbarnUT.kt
@@ -4,7 +4,7 @@ import no.nav.pensjon.regler.domain.kode.FormelKodeCti
 import no.nav.pensjon.regler.domain.kode.YtelsekomponentTypeCti
 import java.io.Serializable
 
-class BarnetilleggSerkullsbarnUT : AbstraktBarnetilleggUT(), Serializable {
+class BarnetilleggSerkullsbarnUT : AbstraktBarnetilleggUT, Serializable {
     /**
      * Brukers gjenlevendetillegg før justering.
      */
@@ -12,6 +12,13 @@ class BarnetilleggSerkullsbarnUT : AbstraktBarnetilleggUT(), Serializable {
 
     init {
         ytelsekomponentType = YtelsekomponentTypeCti("UT_TSB")
+    }
+
+    constructor(barnetilleggFellesbarnUT: BarnetilleggSerkullsbarnUT) : super(barnetilleggFellesbarnUT) {
+        brukersGjenlevendetilleggForJustering = barnetilleggFellesbarnUT.brukersGjenlevendetilleggForJustering
+    }
+
+    constructor() {
         formelKode = FormelKodeCti("BTx")
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/Pensjonstillegg.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/Pensjonstillegg.kt
@@ -13,10 +13,12 @@ open class Pensjonstillegg : Ytelseskomponent {
 
     init {
         ytelsekomponentType = YtelsekomponentTypeCti("PT")
+    }
+
+    constructor() {
         formelKode = FormelKodeCti("PenTx")
     }
 
-    constructor()
     constructor(pt: Pensjonstillegg) : super(pt){
         forholdstall67 = pt.forholdstall67
         minstepensjonsnivaSats = pt.minstepensjonsnivaSats

--- a/src/main/kotlin/no/nav/pensjon/regler/to/SimuleringRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/SimuleringRequest.kt
@@ -3,10 +3,29 @@ package no.nav.pensjon.regler.to
 import no.nav.pensjon.regler.domain.simulering.Simulering
 import java.util.*
 
-class SimuleringRequest : ServiceRequest() {
+class SimuleringRequest : ServiceRequest {
     var simulering: Simulering? = null
     var fom: Date? = null
     var ektefelleMottarPensjon = false
     var beregnForsorgingstillegg = false
     var beregnInstitusjonsopphold = false
+
+    constructor(
+        simulering: Simulering?,
+        fom: Date?,
+        ektefelleMottarPensjon: Boolean,
+        beregnForsorgingstillegg: Boolean,
+        beregnInstitusjonsopphold: Boolean
+    ) {
+        this.simulering = simulering
+        this.fom = fom
+        this.ektefelleMottarPensjon = ektefelleMottarPensjon
+        this.beregnForsorgingstillegg = beregnForsorgingstillegg
+        this.beregnInstitusjonsopphold = beregnInstitusjonsopphold
+    }
+
+    constructor(simulering: Simulering?, fom: Date?) {
+        this.simulering = simulering
+        this.fom = fom
+    }
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovRequest.kt
@@ -5,10 +5,19 @@ import no.nav.pensjon.regler.domain.krav.Kravhode
 import no.nav.pensjon.regler.domain.vedtak.VilkarsVedtak
 import java.util.*
 
-class VilkarsprovRequest : ServiceRequest() {
+class VilkarsprovRequest : ServiceRequest {
     var kravhode: Kravhode? = null
     var sisteBeregning: SisteBeregning? = null
     var fom: Date? = null
     var tom: Date? = null
     var vilkarsvedtakliste: List<VilkarsVedtak> = mutableListOf()
+
+    constructor()
+    constructor(kravhode: Kravhode?, sisteBeregning: SisteBeregning?, fom: Date?, tom: Date?) {
+        this.kravhode = kravhode
+        this.sisteBeregning = sisteBeregning
+        this.fom = fom
+        this.tom = tom
+        this.vilkarsvedtakliste = mutableListOf()
+    }
 }

--- a/src/test/kotlin/no/nav/pensjon/regler/domain/beregning/GrunnpensjonTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/regler/domain/beregning/GrunnpensjonTest.kt
@@ -1,0 +1,21 @@
+package no.nav.pensjon.regler.domain.beregning
+
+import no.nav.pensjon.regler.domain.kode.FormelKodeCti
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class GrunnpensjonTest {
+
+    @Test
+    fun `Skal bevare formelKode ved bruk av copy-constructor`() {
+        val gp = Grunnpensjon()
+
+        assertEquals(gp.formelKode!!.kode, FormelKodeCti("GPx").kode)
+
+        gp.formelKode = FormelKodeCti("BasGP1")
+
+        val gpCopy = Grunnpensjon(gp)
+
+        assertEquals(gpCopy.formelKode!!.kode, FormelKodeCti("BasGP1").kode)
+    }
+}


### PR DESCRIPTION
Ved bruk av copy-constructor for ytelseskomponent vil init-funksjonene overskrive formelKode. 